### PR TITLE
Hotfix: Fix CORS configuration to allow custom domain

### DIFF
--- a/apps/backend/middleware/securityMiddleware.js
+++ b/apps/backend/middleware/securityMiddleware.js
@@ -32,15 +32,17 @@ const corsOptions = {
   origin: (origin, callback) => {
     // Allow requests with no origin (like mobile apps, curl, etc)
     if (!origin) return callback(null, true);
-    
+
     // Check if origin is allowed
     const allowedOrigins = [
       'http://localhost:3000',
       'http://localhost:3001',
       'http://localhost:3002',
+      'http://localhost:3003',
       'https://word-scramble-game.vercel.app',
+      'https://scramble.rcdc.me',
     ];
-    
+
     if (allowedOrigins.indexOf(origin) !== -1 || process.env.NODE_ENV === 'development') {
       callback(null, true);
     } else {
@@ -56,20 +58,20 @@ const corsOptions = {
 const applySecurityMiddleware = (app) => {
   // Set security HTTP headers
   app.use(helmet());
-  
+
   // Enable CORS
   app.use(cors(corsOptions));
-  
+
   // Sanitize data
   app.use(xss());
   app.use(mongoSanitize());
-  
+
   // Apply rate limiting to all requests
   app.use('/api/', limiter);
-  
+
   // Apply game-specific rate limiting
   app.use('/api/game/validate', gameLimiter);
-  
+
   return app;
 };
 

--- a/apps/frontend/services/api.js
+++ b/apps/frontend/services/api.js
@@ -9,7 +9,7 @@ const isLocalhost = typeof window !== 'undefined' &&
 const getBaseURL = () => {
   // If we're on localhost, use the local backend
   if (isLocalhost) {
-    return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
+    return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3003/api';
   }
 
   // For Vercel deployment with monorepo


### PR DESCRIPTION
## Description

This PR fixes the connection refused error in the browser console by updating the CORS configuration to allow the custom domain `scramble.rcdc.me`.

## Changes Made

- Added `https://scramble.rcdc.me` to the list of allowed origins in the CORS configuration
- Added `http://localhost:3003` to the list of allowed origins for local development

## Testing

After this change, the frontend should be able to connect to the backend API when deployed to the custom domain.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author