### PR TITLE
Hotfix: Remove invalid framework property from backend vercel.json

### DIFF
--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -1,7 +1,6 @@
 {
   "buildCommand": "cd ../.. && npm install && cd apps/backend && npm run build",
   "outputDirectory": ".",
-  "framework": "node",
   "ignoreCommand": "exit 0",
   "functions": {
     "server.js": {


### PR DESCRIPTION
## Description

This PR fixes the Vercel deployment error by removing the invalid `framework` property from the backend's `vercel.json` file.

## Changes Made

- Removed the `framework: "node"` property from `apps/backend/vercel.json`

## Error Fixed

The error was: "The `vercel.json` schema validation failed with the following message: `framework` should be equal to one of the allowed values..."

## How to Deploy

After merging this PR, follow the same deployment steps as before:

1. Create a Vercel project for the backend
2. Update the frontend environment variables
3. Test the deployment

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author